### PR TITLE
Query params parser for django request object

### DIFF
--- a/django_connexion/apis/django_api.py
+++ b/django_connexion/apis/django_api.py
@@ -95,7 +95,7 @@ class DjangoApi(AbstractAPI):
             request.method,
             headers=request.headers,
             form=request.POST,
-            query=request.GET,
+            query=dict(request.GET),
             body=body,
             json_getter=lambda: request.content_type == 'application/json' and json.loads(body),
             files=request.FILES,

--- a/django_connexion/apis/django_utils.py
+++ b/django_connexion/apis/django_utils.py
@@ -2,7 +2,6 @@ import functools
 import random
 import re
 import string
-
 from django.http import HttpResponse
 
 PATH_PARAMETER = re.compile(r'\{([^}]*)\}')

--- a/django_connexion/tests/test_basic.py
+++ b/django_connexion/tests/test_basic.py
@@ -16,3 +16,15 @@ def test_yaml_spec(client):
 def test_endpoint(client):
     response = client.post('/helloworld/greeting/ze')
     assert b'Hello ze' in response.content
+
+
+def test_get_query_params(client):
+    first_names = ['Phoebe', 'Frank Jr. Jr.']
+    last_name = 'Buffay'
+    expected_text = 'Phoebe Buffay, Frank Jr. Jr. Buffay'
+
+    response = client.get('/helloworld/names/list',
+                          {'last_name': last_name, 'first_names': first_names})
+    response_text = response.content.decode('utf-8')
+
+    assert response_text == expected_text

--- a/django_connexion/tests/testapp/openapi/helloworld-api.yaml
+++ b/django_connexion/tests/testapp/openapi/helloworld-api.yaml
@@ -28,3 +28,33 @@ paths:
           schema:
             type: string
             example: "dave"
+  /names/list:
+    get:
+      summary: Lists names
+      description: Gets a list of available names.
+      operationId: django_connexion.tests.testapp.views.list_names
+      parameters:
+        - name: last_name
+          in: query
+          required: true
+          description: Last name that will be used to compose the names list
+          schema:
+            type: string
+            example: Williamson
+        - name: first_names
+          in: query
+          required: false
+          description: First names that will be used to compose the names list
+          schema:
+            type: array
+            items:
+              type: string
+            example: ["Meow-two", "Dugtree"]
+      responses:
+        200:
+          description: List names response
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Charmander Jones, Bulbassaur Jones

--- a/django_connexion/tests/testapp/views.py
+++ b/django_connexion/tests/testapp/views.py
@@ -1,5 +1,15 @@
-from django.http import HttpResponse
+from typing import List
+from django.http import HttpResponse, HttpRequest
 
 
-def post_greeting(request, name) -> str:
+def post_greeting(request: HttpRequest, name: str) -> HttpResponse:
     return HttpResponse(f'Hello {name}')
+
+
+def list_names(request: HttpRequest, last_name: str, first_names: List[str] = None) -> HttpResponse:
+    if first_names is None:
+        first_names = ["Pikachu", "Charizard"]
+    if isinstance(first_names, str):
+        first_names = [first_names]
+
+    return HttpResponse(", ".join([f"{fn} {last_name}" for fn in first_names]))


### PR DESCRIPTION
Django's `QueryDict` object in `request.GET` is not the format expected by `ConnexionApi` query field, causing a bug where only the last element/letter of a query param would reach the `views.py` layer, instead of the full word or array.
This is because `ConnexionApi's` `query` expects a dictionary with a `(key, array[values])` pair.